### PR TITLE
Improve maxiter settings

### DIFF
--- a/better_optimize/constants.py
+++ b/better_optimize/constants.py
@@ -37,6 +37,7 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": False,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": [
             "disp",
             "maxiter",
@@ -53,12 +54,14 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": False,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 1000 * n,
         "valid_options": ["disp", "xtol", "ftol", "maxiter", "maxfev", "direc", "return_all"],
     },
     "CG": {
         "uses_grad": True,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": [
             "disp",
             "maxiter",
@@ -75,6 +78,7 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": True,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": [
             "disp",
             "maxiter",
@@ -93,12 +97,14 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": True,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": ["disp", "xtol", "maxiter", "eps", "return_all", "c1", "c2"],
     },
     "L-BFGS-B": {
         "uses_grad": True,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": [
             "disp",
             "maxcor",
@@ -116,6 +122,7 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": True,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: max(100, 10 * n),
         "valid_options": [
             "eps",
             "scale",
@@ -138,12 +145,14 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": False,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 1000,
         "valid_options": ["rhobeg", "tol", "disp", "maxiter", "catol"],
     },
     "SLSQP": {
         "uses_grad": True,
         "uses_hess": False,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 100,
         "valid_options": [
             "ftol",
             "eps",
@@ -156,6 +165,7 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": True,
+        "f_maxiter_default": lambda n: 1000,
         "valid_options": [
             "gtol",
             "xtol",
@@ -176,52 +186,47 @@ MINIMIZE_MODE_KWARGS = {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": ["initial_trust_radius", "max_trust_radius", "eta", "gtol"],
     },
     "trust-ncg": {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": True,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": ["initial_trust_radius", "max_trust_radius", "eta", "gtol"],
     },
     "trust-exact": {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": False,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": ["initial_trust_radius", "max_trust_radius", "eta", "gtol"],
     },
     "trust-krylov": {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": True,
+        "f_maxiter_default": lambda n: 200 * n,
         "valid_options": ["inexact"],
     },
 }
 
-root_method = Literal[
-    "hybr",
-    "lm",
-    "broyden1",
-    "broyden2",
-    "anderson",
-    "linearmixing",
-    "diagbroyden",
-    "excitingmixing",
-    "krylov",
-    "df-sane",
-]
 
 ROOT_MODE_KWARGS = {
     "hybr": {
         "uses_jac": True,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": ["col_deriv", "xtol", "maxfev", "band", "eps", "factor", "diag"],
     },
     "lm": {
         "uses_jac": True,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": ["col_deriv", "ftol", "xtol", "gtol", "maxiter", "eps", "factor", "diag"],
     },
     "broyden1": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -239,6 +244,7 @@ ROOT_MODE_KWARGS = {
     },
     "broyden2": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -256,6 +262,7 @@ ROOT_MODE_KWARGS = {
     },
     "anderson": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -272,6 +279,7 @@ ROOT_MODE_KWARGS = {
     },
     "linearmixing": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -288,6 +296,7 @@ ROOT_MODE_KWARGS = {
     },
     "diagbroyden": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -304,6 +313,7 @@ ROOT_MODE_KWARGS = {
     },
     "excitingmixing": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -320,6 +330,7 @@ ROOT_MODE_KWARGS = {
     },
     "krylov": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "nit",
             "disp",
@@ -343,6 +354,7 @@ ROOT_MODE_KWARGS = {
     },
     "df-sane": {
         "uses_jac": False,
+        "f_maxiter_default": lambda n: 100 * (n + 1),
         "valid_options": [
             "ftol",
             "fatol",

--- a/better_optimize/minimize.py
+++ b/better_optimize/minimize.py
@@ -72,7 +72,7 @@ def minimize(
     optimizer_kwargs["options"] = options
 
     optimizer_kwargs = kwargs_to_options(optimizer_kwargs, method)
-    maxiter, optimizer_kwargs = determine_maxiter(optimizer_kwargs, method)
+    maxiter, optimizer_kwargs = determine_maxiter(optimizer_kwargs, method, len(x0))
     optimizer_kwargs = determine_tolerance(optimizer_kwargs, method)
 
     # Test hessian function -- if it returns a LinearOperator, it can't be used inside the wrapper

--- a/better_optimize/root.py
+++ b/better_optimize/root.py
@@ -71,7 +71,7 @@ def root(
     optimizer_kwargs = kwargs_to_options(optimizer_kwargs, method)
     optimizer_kwargs = kwargs_to_jac_options(optimizer_kwargs, method)
 
-    maxiter, optimizer_kwargs = determine_maxiter(optimizer_kwargs, method)
+    maxiter, optimizer_kwargs = determine_maxiter(optimizer_kwargs, method, len(x0))
     optimizer_kwargs = determine_tolerance(optimizer_kwargs, method)
 
     objective = ObjectiveWrapper(

--- a/better_optimize/utilities.py
+++ b/better_optimize/utilities.py
@@ -36,7 +36,7 @@ def validate_provided_functions_minimize(
     verbose=True,
 ) -> None:
     has_grad, has_hess, has_hessp = map(lambda f: f is not None, [f_grad, f_hess, f_hessp])
-    uses_grad, uses_hess, uses_hessp, _ = MINIMIZE_MODE_KWARGS[method].values()
+    uses_grad, uses_hess, uses_hessp, *_ = MINIMIZE_MODE_KWARGS[method].values()
 
     if has_fused_f_and_grad and has_grad:
         _log.warning(

--- a/better_optimize/wrapper.py
+++ b/better_optimize/wrapper.py
@@ -123,12 +123,17 @@ class ObjectiveWrapper:
             value_dict["hess_norm"] = hess_norm
 
         if self.n_eval == 0:
-            self.task = self.progress.add_task("Optimizing", **value_dict)
+            self.task = self.progress.add_task(
+                "Optimizing", total=self.maxeval, refresh=True, **value_dict
+            )
 
         if not completed:
             self.progress.update(self.task, advance=self.update_every, **value_dict)
         else:
-            self.progress.update(self.task, total=self.n_eval, completed=self.n_eval, **value_dict)
+            self.progress.update(
+                self.task, total=self.n_eval, completed=self.n_eval, refresh=True, **value_dict
+            )
+            self.progress.stop()
 
     def initialize_progress_bar(self):
         text_column = TextColumn("{task.description}", table_column=Column(ratio=1))

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -84,7 +84,7 @@ def rosen_fused(x, a, b):
 def test_rosen(method: minimize_method):
     x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
 
-    res = minimize(partial(rosen, a=100, b=0), x0, method=method, tol=1e-8)
+    res = minimize(partial(rosen, a=100, b=0), x0, method=method, tol=1e-8, maxiter=5000)
 
     assert isinstance(res, OptimizeResult)
     assert_allclose(res.x, np.ones(5), atol=1e-5, rtol=1e-5)
@@ -95,7 +95,7 @@ def test_rosen(method: minimize_method):
 def test_rosen_with_args(method: minimize_method):
     x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
 
-    res = minimize(rosen, x0, method=method, args=(0.5, 1.0), tol=1e-20, maxiter=1000)
+    res = minimize(rosen, x0, method=method, args=(0.5, 1.0), tol=1e-20, maxiter=5000)
 
     assert isinstance(res, OptimizeResult)
     assert_allclose(res.x, np.ones(5), atol=1e-5, rtol=1e-5)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -56,7 +56,7 @@ def test_validate_provided_functions_raises_on_two_hess(settings, method: minimi
 
 @pytest.mark.parametrize("method", methods, ids=methods)
 def test_validate_provided_functions_warnings(caplog, settings, method: minimize_method):
-    uses_grad, uses_hess, uses_hessp, _ = MINIMIZE_MODE_KWARGS[method].values()
+    uses_grad, uses_hess, uses_hessp, *_ = MINIMIZE_MODE_KWARGS[method].values()
 
     for f_grad, f_hess, f_hessp in settings:
         use_grad, use_hess, use_hessp = map(func_not_none, (f_grad, f_hess, f_hessp))


### PR DESCRIPTION
Correctly set maxiter on the progress bar, and use scipy defaults when maxiter is not provided.