### PR TITLE
Set progress labels based on task

### DIFF
--- a/better_optimize/minimize.py
+++ b/better_optimize/minimize.py
@@ -88,6 +88,7 @@ def minimize(
         args=args,
         progressbar=progressbar,
         has_fused_f_and_grad=has_fused_f_and_grad,
+        root=False,
     )
 
     f_optim = partial(

--- a/better_optimize/root.py
+++ b/better_optimize/root.py
@@ -81,6 +81,7 @@ def root(
         args=args,
         progressbar=progressbar,
         has_fused_f_and_grad=has_fused_f_and_grad,
+        root=True,
     )
 
     f_optim = partial(


### PR DESCRIPTION
When using `root`, the progress bar shows `f= ... ` and `||jac|| = `, rather than `||grad|| = `. `minimize` still shows the gradient norm. Also change the verb based on which function is being called ("Minimize" or "Finding Roots") 