### PR TITLE
Use context manager for progress bar

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -48,7 +48,7 @@ jobs:
           hashFiles('requirements.txt') }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         mamba-version: "*"
         activate-environment: better_optimize


### PR DESCRIPTION
Uses the `rich` progress bar in a context manager, rather than the start/stop API. This should prevent cleanup errors from unexpected termination.

Also adds better handling for the case where the progress bar is disabled.