### PR TITLE
Allow basinhopping to move on minimizer failure

### DIFF
--- a/better_optimize/wrapper.py
+++ b/better_optimize/wrapper.py
@@ -15,6 +15,7 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 from rich.table import Column
+from scipy.optimize import OptimizeResult
 
 from better_optimize.utilities import ToggleableProgress
 
@@ -188,10 +189,12 @@ def optimizer_early_stopping_wrapper(f_optim: partial):
         except (KeyboardInterrupt, StopIteration):
             # Teardown the progress bar if necessary, then forward the error
             final_value = objective.previous_x
-            res = {"x": final_value, "fun": objective.step(final_value)}
-            _log.warning(
-                "Execution interrupted and callback failed! Returning partial results as a dictionary "
-                "(not a scipy.optimize.OptimizeResult)."
+            res = OptimizeResult(
+                x=final_value,
+                fun=objective.previous_x,
+                success=False,
+                message="`StopIteration` or `KeyboardInterrupt` raised -- optimization stopped "
+                "prematurely.",
             )
         except Exception as e:
             raise e

--- a/tests/test_basinhopping.py
+++ b/tests/test_basinhopping.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from better_optimize.basinhopping import basinhopping
+from better_optimize.basinhopping import AllowFailureStorage, basinhopping
+from better_optimize.utilities import ToggleableProgress
 
 
 def func1d(x):
@@ -19,6 +20,7 @@ def func2d(x):
     df = np.zeros(2)
     df[0] = -14.5 * np.sin(14.5 * x[0] - 0.3) + 2.0 * x[0] + 0.2
     df[1] = 2.0 * x[1] + 0.2
+
     return f, df
 
 
@@ -28,6 +30,14 @@ def func2d_easyderiv(x):
     df[0] = 4.0 * x[0] + 2.0 * x[1] - 6.0
     df[1] = 2.0 * x[0] + 4.0 * x[1]
 
+    return f, df
+
+
+def func2d_hard_fused(x):
+    f = np.sin(5 * np.pi * x[0]) * (1 - x[0]) + (x[1] - 0.5) ** 2
+    df = np.zeros_like(x)
+    df[0] = 5 * np.pi * np.cos(5 * np.pi * x[0]) * (1 - x[0]) - np.sin(5 * np.pi * x[0])
+    df[1] = 2 * (x[1] - 0.5)
     return f, df
 
 
@@ -67,6 +77,78 @@ def test_basinhopping_nograd():
 
     assert res.success is True
     np.testing.assert_allclose(res.x, np.array([-0.195, -0.1]), atol=1e-3, rtol=1e-3)
+
+
+def test_progress_global_gradient_updates_on_new_minimum(monkeypatch):
+    gradient_updates = []
+    original_update = ToggleableProgress.update
+
+    def mock_update(self, task_id, **kwargs):
+        if "grad_norm" in kwargs and task_id == 0:
+            gradient_updates.append(kwargs["grad_norm"])
+        return original_update(self, task_id, **kwargs)
+
+    monkeypatch.setattr("better_optimize.utilities.ToggleableProgress.update", mock_update)
+
+    basinhopping(
+        func2d_hard_fused,
+        x0=[0.8, 0.8],  # Start away from the global minimum
+        minimizer_kwargs={"method": "L-BFGS-B", "jac": True},
+        niter=10,
+        progressbar=True,
+        accept_on_minimizer_fail=True,
+    )
+    assert (
+        len(gradient_updates) > 0
+    ), "No gradient norm updates were recorded for the global minimum."
+    assert all(
+        isinstance(grad, float) for grad in gradient_updates
+    ), "Invalid gradient norm values for the global minimum."
+    assert all(grad > 0 for grad in gradient_updates), "Gradient norm values should be positive."
+
+
+def test_move_to_new_minimum_on_optimizer_failure(monkeypatch):
+    import importlib
+
+    # Required, because otherwise monkeypatch can't find the *module* basinhopping; only the function
+    bh_module = importlib.import_module("better_optimize.basinhopping")
+    original_minimize = bh_module.minimize
+    original_storage_update = AllowFailureStorage.update
+
+    global_minima = []
+
+    # Mock the inner optimizer to always fail
+    def mock_minimize(*args, **kwargs):
+        res = original_minimize(*args, **kwargs)
+        res["success"] = False
+        return res
+
+    # Track when the storage accepts a new minimum
+    def mock_storage_update(self, minres):
+        result = original_storage_update(self, minres)
+        if result:  # If the update was accepted
+            global_minima.append(minres.fun)
+        return result
+
+    monkeypatch.setattr(bh_module, "minimize", mock_minimize)
+    monkeypatch.setattr(AllowFailureStorage, "update", mock_storage_update)
+
+    basinhopping(
+        func2d_hard_fused,
+        x0=[0.8, 0.8],  # Start away from the global minimum
+        minimizer_kwargs={"method": "L-BFGS-B", "jac": True},
+        niter=10,
+        progressbar=False,
+        accept_on_minimizer_fail=True,
+    )
+
+    global_minima = np.stack(global_minima)
+
+    # Ensure the global minimum values are monotonically decreasing
+    assert len(global_minima) > 0, "No global minima were recorded."
+
+    minima_diff = np.diff(global_minima)[1:]
+    assert (minima_diff <= 0.0).all(), "Global minima are not monotonically decreasing."
 
 
 if __name__ == "__main__":

--- a/tests/util/error_script.py
+++ b/tests/util/error_script.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 from functools import partial
 
@@ -35,7 +36,7 @@ def main():
     root = args.root
     method = args.method
 
-    objective = ObjectiveWrapper(f=f, root=root)
+    objective = ObjectiveWrapper(f=f, root=root, progressbar=False)
 
     f_optim = partial(
         scipy_root if root else scipy_minimize,
@@ -47,7 +48,16 @@ def main():
 
     res = optimizer_early_stopping_wrapper(f_optim)
 
-    return res
+    # Save result as a serializable JSON
+    output = {
+        "x": res.x.tolist(),
+        "fun": res.fun if not root else res.fun.tolist(),
+        "success": res.success,
+        "message": res.message,
+    }
+    output = json.dumps(output)
+
+    return output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current behavior of scipy.optimize.basinhopping is to always reject a new point if the inner optimizer fails, even if the loss is an improvement over the current point. In certain cases, it might be desirable to accept such points. The feature is requested [here](https://github.com/scipy/scipy/issues/22195), for example.