### PR TITLE
Drop upper bound on Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = 'better_optimize'
 dynamic = ['version']
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 description = "A drop-in replacement for scipy optimize functions with quality of life improvements"
 readme = "README.md"
 license = {text = "MIT License"}


### PR DESCRIPTION
Suggestion: Python usually has extremely good backwards compatibility, so often having such an upper bound does more harm than good.

Until recently I used to favor these sorts of upper bounds with thorough testing, but my view has since shifted.