### PR TITLE
Auto-promote more keyword arguments for trust-region algorithms 

### DIFF
--- a/better_optimize/constants.py
+++ b/better_optimize/constants.py
@@ -194,21 +194,34 @@ MINIMIZE_MODE_KWARGS = {
         "uses_hess": True,
         "uses_hessp": True,
         "f_maxiter_default": lambda n: 200 * n,
-        "valid_options": ["initial_trust_radius", "max_trust_radius", "eta", "gtol"],
+        "valid_options": ["initial_trust_radius", "max_trust_radius", "eta", "gtol", "workers"],
     },
     "trust-exact": {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": False,
         "f_maxiter_default": lambda n: 200 * n,
-        "valid_options": ["initial_trust_radius", "max_trust_radius", "eta", "gtol"],
+        "valid_options": [
+            "initial_trust_radius",
+            "max_trust_radius",
+            "eta",
+            "gtol",
+            "subproblem_maxiter",
+        ],
     },
     "trust-krylov": {
         "uses_grad": True,
         "uses_hess": True,
         "uses_hessp": True,
         "f_maxiter_default": lambda n: 200 * n,
-        "valid_options": ["inexact"],
+        "valid_options": [
+            "inexact",
+            "initial_trust_radius",
+            "max_trust_radius",
+            "eta",
+            "gtol",
+            "workers",
+        ],
     },
 }
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -165,9 +165,23 @@ def test_determine_tolerance(method: minimize_method):
 
     expected_options = sorted(MINIMIZE_MODE_KWARGS[method]["valid_options"])
 
-    # trust-constr docstring is really messy, just skip
-    if method != "trust-constr":
-        assert all(x in all_options for x in expected_options)
+    # This sucks, but the scipy docstrings are not very consistent and some options are not documented. I hardcode the
+    # missing options here
+    undocumented_options = {
+        "trust-ncg": {"workers"},
+        "trust-krylov": {"workers", "eta", "max_trust_radius", "initial_trust_radius", "gtol"},
+        "trust-exact": {"subproblem_maxiter"},
+        "trust-constr": {
+            "initial_barrier_parameter",
+            "initial_tr_radius",
+            "initial_barrier_tolerance",
+        },
+    }
+
+    missing_options = (
+        set(expected_options) - set(all_options) - set(undocumented_options.get(method, []))
+    )
+    assert not missing_options, "missing options: " + ", ".join(missing_options)
 
     expected_tols = [x for x in expected_options if x in TOLERANCES]
     assert all(options[tol] == 1e-8 for tol in expected_tols)


### PR DESCRIPTION
Several arguments for trust-region minimization algorithms (trust-ncg, trust-krylov, trust-exact) are not documented. This PR moves all valid kwargs into the options dictionary for users.