### PR TITLE
Catch optimization errors gracefully and return

### DIFF
--- a/better_optimize/multi_optimize.py
+++ b/better_optimize/multi_optimize.py
@@ -177,8 +177,22 @@ def _run_single(
         if blas_cores_per_worker is not None
         else contextlib.nullcontext()
     )
-    with limiter:
-        result = solver(x0=x0, progressbar=progress, progress_task=task_id, **solver_kwargs)
+    try:
+        with limiter:
+            result = solver(x0=x0, progressbar=progress, progress_task=task_id, **solver_kwargs)
+    except Exception as exc:
+        _log.warning(
+            "Run %d failed with %s: %s",
+            run_index,
+            type(exc).__name__,
+            exc,
+        )
+        result = OptimizeResult(
+            x=x0,
+            fun=np.inf,
+            success=False,
+            message=f"Solver raised {type(exc).__name__}: {exc}",
+        )
 
     result.run_index = run_index
     result.x0 = x0

--- a/better_optimize/wrapper.py
+++ b/better_optimize/wrapper.py
@@ -235,20 +235,40 @@ def optimizer_early_stopping_wrapper(f_optim: partial):
                 "prematurely.",
             )
         except Exception as e:
-            raise e
+            # Catch any runtime errors from the optimizer (e.g. nan/inf) and return a failed
+            # result instead of crashing.
+            _log.warning("Optimizer raised %s: %s", type(e).__name__, e)
+            final_value = objective.previous_x
+            x0 = f_optim.keywords.get("x0")
+            if final_value is None:
+                final_value = x0
+            res = OptimizeResult(
+                x=final_value,
+                fun=np.inf,
+                success=False,
+                message=f"Optimizer raised {type(e).__name__}: {e}",
+            )
 
-        outputs = objective.step(final_value)
+        # Guard against final_value being None (can happen if no finite
+        # iterate was ever recorded and no x0 was available).
+        if final_value is not None:
+            try:
+                outputs = objective.step(final_value)
 
-        if not objective.use_jac and not objective.use_hess:
-            value = outputs
-            grad = None
-            hess = None
-        elif objective.use_jac and not objective.use_hess:
-            value, grad = outputs
-            hess = None
-        else:
-            value, grad, hess = outputs
+                if not objective.use_jac and not objective.use_hess:
+                    value = outputs
+                    grad = None
+                    hess = None
+                elif objective.use_jac and not objective.use_hess:
+                    value, grad = outputs
+                    hess = None
+                else:
+                    value, grad, hess = outputs
 
-        objective.update_progressbar(value, grad, hess, completed=True)
+                objective.update_progressbar(value, grad, hess, completed=True)
+            except Exception:
+                # If the final evaluation itself fails (e.g. NaN inputs),
+                # just mark the progress bar as complete.
+                _log.debug("Final evaluation failed; skipping progress-bar update.", exc_info=True)
 
     return res

--- a/tests/test_multistart.py
+++ b/tests/test_multistart.py
@@ -263,19 +263,27 @@ def test_run_single_attaches_metadata():
     assert_allclose(result.x0, x0)
 
 
-def test_run_single_propagates_solver_exception():
-    def exploding_solver(x0, **kwargs):
-        raise RuntimeError("solver exploded")
+def test_run_single_catches_solver_exception():
+    """Solver exceptions are caught and returned as failed OptimizeResults."""
 
-    with pytest.raises(RuntimeError, match="solver exploded"):
-        _run_single(
-            run_index=0,
-            x0=np.zeros(2),
-            solver=exploding_solver,
-            solver_kwargs={},
-            progress=MagicMock(),
-            task_id=0,
-        )
+    def exploding_solver(x0, **kwargs):
+        raise RuntimeError("NaN encountered")
+
+    x0 = np.array([1.0, 2.0])
+    result = _run_single(
+        run_index=3,
+        x0=x0,
+        solver=exploding_solver,
+        solver_kwargs={},
+        progress=MagicMock(),
+        task_id=0,
+    )
+    assert not result.success
+    assert result.fun == np.inf
+    assert "RuntimeError" in result.message
+    assert result.run_index == 3
+    assert_allclose(result.x0, x0)
+    assert_allclose(result.x, x0)
 
 
 class TestMultiStartResult:
@@ -431,3 +439,34 @@ def test_multistart_pickle_fallback(caplog):
     # Fallback may or may not trigger depending on environment,
     # but either way we must get valid results.
     assert len(result.results) == 2
+
+
+def test_multistart_survives_crashing_solver():
+    """A solver that raises for some starting points should not kill the campaign."""
+    call_count = 0
+
+    def sometimes_exploding_solver(x0, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count % 2 == 0:
+            raise RuntimeError("NaN in trust region subproblem")
+        return OptimizeResult(x=x0, fun=float(np.sum(x0**2)), success=True)
+
+    x0_list = [np.ones(2) * i for i in range(4)]
+    result = multi_optimize(
+        solver=sometimes_exploding_solver,
+        x0=x0_list,
+        backend="sequential",
+        progressbar=False,
+        blas_cores=None,
+    )
+
+    assert len(result.results) == 4
+    n_success = sum(r.success for r in result.results)
+    n_failed = sum(not r.success for r in result.results)
+    assert n_success == 2
+    assert n_failed == 2
+    for r in result.results:
+        if not r.success:
+            assert r.fun == np.inf
+            assert "RuntimeError" in r.message

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -43,7 +43,8 @@ def test_early_return_from_keyboard_interrupt(root, method):
 
 
 @pytest.mark.parametrize("root", [True, False], ids=["root", "minimize"])
-def test_execption_breaks_optimization(root, monkeypatch):
+def test_exception_returns_failed_result(root, monkeypatch):
+    """Exceptions raised inside the optimizer should be caught and returned as a failed result."""
     N_EXEC = 0
 
     def f(x: np.ndarray):
@@ -64,9 +65,9 @@ def test_execption_breaks_optimization(root, monkeypatch):
         callback=objective.callback,
     )
 
-    # Non-KeyboardInterrupt exceptions should break execution.
-    with pytest.raises(Exception, match="Simulated error"):
-        optimizer_early_stopping_wrapper(f_optim)
+    result = optimizer_early_stopping_wrapper(f_optim)
+    assert not result.success
+    assert "Simulated error" in result.message
 
 
 def func2(x, a, b):


### PR DESCRIPTION
Scipy isn't nice about catching runtime errors in their optimizers. This can currently kill an entire multi-run if one worker panics. This PR catches errors and returns a failed OptimizationResult object if we hit a runtime error (or anything else). One worker must die so the others might live! 